### PR TITLE
SQLLeaseProxy implementation

### DIFF
--- a/src/Microsoft.Azure.WebJobs.Host/Lease/SqlLeaseProxy.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Lease/SqlLeaseProxy.cs
@@ -4,16 +4,12 @@
 using System;
 using System.Collections.Generic;
 using System.Data;
-using System.Data.Common;
-using System.Data.Odbc;
 using System.Data.SqlClient;
 using System.Globalization;
 using System.Linq;
 using System.Net;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.Azure.WebJobs.Host.Lease;
 using Newtonsoft.Json;
 
 namespace Microsoft.Azure.WebJobs.Host.Lease
@@ -21,6 +17,9 @@ namespace Microsoft.Azure.WebJobs.Host.Lease
     // Sql based lease implementation
     internal class SqlLeaseProxy : ILeaseProxy
     {
+        // TODO: Avoid using a process wide InstanceId.
+        private static readonly string InstanceId = Guid.NewGuid().ToString();
+
         public static bool IsSqlLeaseType()
         {
             try
@@ -48,40 +47,262 @@ namespace Microsoft.Azure.WebJobs.Host.Lease
         }
 
         /// <inheritdoc />
-        public Task<string> TryAcquireLeaseAsync(LeaseDefinition leaseDefinition, CancellationToken cancellationToken)
+        public async Task<string> TryAcquireLeaseAsync(LeaseDefinition leaseDefinition, CancellationToken cancellationToken)
         {
-            throw new NotImplementedException();
+            if (leaseDefinition == null)
+            {
+                throw new ArgumentNullException(nameof(leaseDefinition));
+            }
+
+            string leaseId = null;
+            try
+            {
+                leaseId = await AcquireLeaseAsync(leaseDefinition, cancellationToken);
+            }
+            catch (Exception)
+            {
+            }
+
+            return leaseId;
         }
 
         /// <inheritdoc />
-        public Task<string> AcquireLeaseAsync(LeaseDefinition leaseDefinition, CancellationToken cancellationToken)
+        public async Task<string> AcquireLeaseAsync(LeaseDefinition leaseDefinition, CancellationToken cancellationToken)
         {
-            throw new NotImplementedException();
+            if (leaseDefinition == null)
+            {
+                throw new ArgumentNullException(nameof(leaseDefinition));
+            }
+
+            try
+            {
+                bool isAcquired = await TryAcquireOrRenewLeaseAsync(leaseDefinition, cancellationToken);
+
+                if (isAcquired)
+                {
+                    return GetLeaseId(leaseDefinition);
+                }
+
+                throw new LeaseException(LeaseFailureReason.Conflict, null);
+            }
+            catch (LeaseException)
+            {
+                throw;
+            }
+            catch (Exception ex)
+            {
+                throw new LeaseException(LeaseFailureReason.Unknown, ex);
+            }
         }
 
         /// <inheritdoc />
-        public Task RenewLeaseAsync(LeaseDefinition leaseDefinition, CancellationToken cancellationToken)
+        public async Task RenewLeaseAsync(LeaseDefinition leaseDefinition, CancellationToken cancellationToken)
         {
-            throw new NotImplementedException();
+            if (leaseDefinition == null)
+            {
+                throw new ArgumentNullException(nameof(leaseDefinition));
+            }
+
+            try
+            {
+                // TODO: Update implementation to use LeaseDefinition.LeaseId for lease renewal
+                bool isAcquired = await TryAcquireOrRenewLeaseAsync(leaseDefinition, cancellationToken);
+
+                if (!isAcquired)
+                {
+                    throw new LeaseException(LeaseFailureReason.Conflict, null);
+                }
+            }
+            catch (LeaseException)
+            {
+                throw;
+            }
+            catch (Exception ex)
+            {
+                throw new LeaseException(LeaseFailureReason.Unknown, ex);
+            }
         }
 
         /// <inheritdoc />
-        public Task WriteLeaseMetadataAsync(LeaseDefinition leaseDefinition, string key,
+        public async Task WriteLeaseMetadataAsync(LeaseDefinition leaseDefinition, string key,
             string value, CancellationToken cancellationToken)
         {
-            throw new NotImplementedException();
+            if (leaseDefinition == null)
+            {
+                throw new ArgumentNullException(nameof(leaseDefinition));
+            }
+
+            if (string.IsNullOrWhiteSpace(key))
+            {
+                throw new ArgumentNullException(nameof(key));
+            }
+
+            try
+            {
+                var metadata = new Dictionary<string, string> { { key, value } };
+
+                var connectionString = GetConnectionString(leaseDefinition.AccountName);
+
+                using (SqlConnection connection = new SqlConnection(connectionString))
+                {
+                    await connection.OpenAsync(cancellationToken);
+
+                    using (SqlCommand cmd = connection.CreateCommand())
+                    {
+                        cmd.CommandType = CommandType.StoredProcedure;
+                        cmd.CommandText = "[functions].[leases_updateMetadata]";
+                        cmd.Parameters.Add("@LeaseName", SqlDbType.NVarChar, 127).Value = GetLeaseId(leaseDefinition);
+                        cmd.Parameters.Add("@RequestorName", SqlDbType.NVarChar, 127).Value = InstanceId;
+                        cmd.Parameters.Add("@Metadata", SqlDbType.NVarChar).Value = JsonConvert.SerializeObject(metadata);
+                        cmd.Parameters.Add("@Successful", SqlDbType.Bit).Direction = ParameterDirection.Output;
+
+                        await cmd.ExecuteNonQueryAsync(cancellationToken);
+
+                        var successful = (bool)cmd.Parameters["@Successful"].Value;
+
+                        // Assume failure is due to expired lease. Technically, we might have failed to set the metadata because 
+                        // the db contains no entry for the specified lease name. If we need to be accurate about the error,
+                        // Update the stored proc to provide detailed status values instead of just a bool. For now, keeping it simple
+                        if (!successful)
+                        {
+                            throw new LeaseException(LeaseFailureReason.Conflict, null);
+                        }
+                    }
+                }
+            }
+            catch (LeaseException)
+            {
+                throw;
+            }
+            catch (Exception ex)
+            {
+                throw new LeaseException(LeaseFailureReason.Unknown, ex);
+            }
         }
 
         /// <inheritdoc />
-        public Task<LeaseInformation> ReadLeaseInfoAsync(LeaseDefinition leaseDefinition, CancellationToken cancellationToken)
+        public async Task<LeaseInformation> ReadLeaseInfoAsync(LeaseDefinition leaseDefinition, CancellationToken cancellationToken)
         {
-            throw new NotImplementedException();
+            if (leaseDefinition == null)
+            {
+                throw new ArgumentNullException(nameof(leaseDefinition));
+            }
+
+            try
+            {
+                var connectionString = GetConnectionString(leaseDefinition.AccountName);
+
+                using (SqlConnection connection = new SqlConnection(connectionString))
+                {
+                    await connection.OpenAsync(cancellationToken);
+
+                    using (SqlCommand cmd = connection.CreateCommand())
+                    {
+                        cmd.CommandType = CommandType.StoredProcedure;
+                        cmd.CommandText = "[functions].leases_getMetadata";
+                        cmd.Parameters.Add("@LeaseName", SqlDbType.NVarChar, 127).Value = GetLeaseId(leaseDefinition);
+                        cmd.Parameters.Add("@RequestorName", SqlDbType.NVarChar, 127).Value = InstanceId;
+                        cmd.Parameters.Add("@Metadata", SqlDbType.NVarChar, -1).Direction = ParameterDirection.Output;
+                        cmd.Parameters.Add("@HasLease", SqlDbType.Bit).Direction = ParameterDirection.Output;
+                        await cmd.ExecuteNonQueryAsync(cancellationToken);
+
+                        var hasLease = (bool)cmd.Parameters["@HasLease"].Value;
+
+                        var serializedMetadata = (string)cmd.Parameters["@Metadata"].Value;
+
+                        Dictionary<string, string> metadataDict;
+
+                        if (string.IsNullOrEmpty(serializedMetadata))
+                        {
+                            metadataDict = new Dictionary<string, string>();
+                        }
+                        else
+                        {
+                            metadataDict = JsonConvert.DeserializeObject<Dictionary<string, string>>(serializedMetadata);
+                        }
+
+                        // We don't want to fail even if the lease is not active
+                        return new LeaseInformation(hasLease, metadataDict);
+                    }
+                }
+            }
+            catch (SqlException ex)
+            {
+                throw new LeaseException(LeaseFailureReason.Unknown, ex);
+            }
         }
 
         /// <inheritdoc />
-        public Task ReleaseLeaseAsync(LeaseDefinition leaseDefinition, CancellationToken cancellationToken)
+        public async Task ReleaseLeaseAsync(LeaseDefinition leaseDefinition, CancellationToken cancellationToken)
         {
-            throw new NotImplementedException();
+            if (leaseDefinition == null)
+            {
+                throw new ArgumentNullException(nameof(leaseDefinition));
+            }
+
+            try
+            {
+                var connectionString = GetConnectionString(leaseDefinition.AccountName);
+
+                using (SqlConnection connection = new SqlConnection(connectionString))
+                {
+                    await connection.OpenAsync(cancellationToken);
+
+                    using (SqlCommand cmd = connection.CreateCommand())
+                    {
+                        cmd.CommandType = CommandType.StoredProcedure;
+                        cmd.CommandText = "[functions].[leases_release]";
+                        cmd.Parameters.Add("@LeaseName", SqlDbType.NVarChar, 127).Value = GetLeaseId(leaseDefinition);
+                        cmd.Parameters.Add("@RequestorName", SqlDbType.NVarChar, 127).Value = InstanceId;
+
+                        await cmd.ExecuteNonQueryAsync(cancellationToken);
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                throw new LeaseException(LeaseFailureReason.Unknown, ex);
+            }
+        }
+
+        private async Task<bool> TryAcquireOrRenewLeaseAsync(LeaseDefinition leaseDefinition, CancellationToken cancellationToken)
+        {
+            var connectionString = GetConnectionString(leaseDefinition.AccountName);
+
+            using (SqlConnection connection = new SqlConnection(connectionString))
+            {
+                await connection.OpenAsync(cancellationToken);
+                using (SqlCommand cmd = connection.CreateCommand())
+                {
+                    cmd.CommandType = CommandType.StoredProcedure;
+                    cmd.CommandText = "[functions].[leases_tryAcquireOrRenew]";
+                    cmd.Parameters.Add("@LeaseName", SqlDbType.NVarChar, 127).Value = GetLeaseId(leaseDefinition);
+                    cmd.Parameters.Add("@RequestorName", SqlDbType.NVarChar, 127).Value = InstanceId;
+                    cmd.Parameters.Add("@LeaseExpirationTimeSpan", SqlDbType.Int).Value = leaseDefinition.Period.TotalSeconds;
+                    cmd.Parameters.Add("@HasLease", SqlDbType.Bit).Direction = ParameterDirection.Output;
+
+                    await cmd.ExecuteNonQueryAsync(cancellationToken);
+
+                    return (bool)cmd.Parameters["@HasLease"].Value;
+                }
+            }
+        }
+
+        private static string GetLeaseId(LeaseDefinition leaseDefinition)
+        {
+            if (leaseDefinition.Namespaces == null || leaseDefinition.Namespaces.Count < 1 || leaseDefinition.Namespaces.Count > 2)
+            {
+                throw new InvalidOperationException(String.Format(CultureInfo.InvariantCulture, "Invalid LeaseDefinition Namespaces: {0}", leaseDefinition.Namespaces));
+            }
+
+            string leaseId = WebUtility.UrlEncode(leaseDefinition.Namespaces[0]);
+
+            if (leaseDefinition.Namespaces.Count == 2)
+            {
+                leaseId += "&" + WebUtility.UrlEncode(leaseDefinition.Namespaces[1]);
+            }
+
+            return leaseId;
         }
 
         private static string GetConnectionString(string accountName)

--- a/src/Microsoft.Azure.WebJobs.Host/Lease/setup.sql
+++ b/src/Microsoft.Azure.WebJobs.Host/Lease/setup.sql
@@ -1,0 +1,127 @@
+-- Copyright (c) .NET Foundation. All rights reserved.
+-- Licensed under the MIT License. See License.txt in the project root for license information.
+
+IF NOT EXISTS (SELECT * FROM sys.schemas WHERE name = N'functions')
+    EXEC sys.sp_executesql N'CREATE SCHEMA [functions] AUTHORIZATION [dbo]'
+GO
+
+IF OBJECT_ID(N'[functions].[Leases]', 'U') IS NULL
+BEGIN
+    CREATE TABLE [functions].[Leases]
+    (
+        [LeaseName] [nvarchar](127) NOT NULL,
+        [RequestorName] [nvarchar](127) NOT NULL,
+        [LastRenewal] [datetime2](7) NOT NULL,
+        [HasLease] [bit] NOT NULL,
+        [Metadata] [nvarchar](max) NULL,
+        [LeaseExpirationTimeSpan] [int] NULL, -- unit is seconds
+        CONSTRAINT [PK_Leases] PRIMARY KEY CLUSTERED
+        (
+            [LeaseName] ASC,
+            [RequestorName] ASC
+        )
+        WITH (PAD_INDEX = OFF, STATISTICS_NORECOMPUTE = OFF, IGNORE_DUP_KEY = OFF, ALLOW_ROW_LOCKS = ON, ALLOW_PAGE_LOCKS = ON)
+    )
+END
+GO
+
+IF OBJECT_ID('[functions].[leases_tryAcquireOrRenew]') IS NULL
+BEGIN
+    EXEC('CREATE PROCEDURE [functions].[leases_tryAcquireOrRenew] AS SET NOCOUNT ON');
+END
+GO
+
+ALTER PROCEDURE [functions].[leases_tryAcquireOrRenew]
+@LeaseName NVARCHAR (127), @RequestorName NVARCHAR (127), @LeaseExpirationTimeSpan INT, @HasLease BIT OUTPUT
+AS
+BEGIN
+    SET NOCOUNT ON;
+
+    BEGIN TRANSACTION
+
+    UPDATE  [functions].[Leases] SET [LastRenewal] = CURRENT_TIMESTAMP, [LeaseExpirationTimeSpan] = @LeaseExpirationTimeSpan WHERE [LeaseName] = @LeaseName AND [RequestorName] = @RequestorName
+    IF @@ROWCOUNT = 0
+        INSERT INTO [functions].[Leases] ([LeaseName], [RequestorName], [LeaseExpirationTimeSpan], [LastRenewal], [HasLease])
+        VALUES (@LeaseName, @RequestorName, @LeaseExpirationTimeSpan, CURRENT_TIMESTAMP, 0)
+
+    UPDATE [functions].[Leases]
+    SET [HasLease] = 0
+    WHERE [LeaseName] = @LeaseName AND [HasLease] = 1 AND [RequestorName] <> @RequestorName AND DATEDIFF(SECOND, [LastRenewal], CURRENT_TIMESTAMP) > @LeaseExpirationTimeSpan
+
+    IF NOT EXISTS (SELECT * FROM [functions].[Leases] WHERE [LeaseName] = @LeaseName AND [HasLease] = 1)
+        UPDATE [functions].[Leases]
+        SET [HasLease] = 1
+        WHERE [LeaseName] = @LeaseName AND [RequestorName] = @RequestorName
+
+    COMMIT TRANSACTION
+
+    SELECT @HasLease = [HasLease] FROM [functions].[Leases] WHERE [LeaseName] = @LeaseName AND [RequestorName] = @RequestorName
+END
+GO
+
+IF OBJECT_ID('[functions].[leases_release]') IS NULL
+BEGIN
+    EXEC('CREATE PROCEDURE [functions].[leases_release] AS SET NOCOUNT ON');
+END
+GO
+
+ALTER PROCEDURE [functions].[leases_release]
+@LeaseName NVARCHAR (127), @RequestorName NVARCHAR (127)
+AS
+BEGIN
+    SET NOCOUNT ON;
+    UPDATE [functions].[Leases] SET [HasLease] = 0 WHERE [LeaseName] = @LeaseName AND [RequestorName] = @RequestorName
+END
+GO
+
+IF OBJECT_ID('[functions].[leases_updateMetadata]') IS NULL
+BEGIN
+    EXEC('CREATE PROCEDURE [functions].[leases_updateMetadata] AS SET NOCOUNT ON');
+END
+GO
+
+ALTER PROCEDURE [functions].[leases_updateMetadata]
+@LeaseName NVARCHAR (127), @RequestorName NVARCHAR (127), @Metadata NVARCHAR(MAX), @Successful BIT OUTPUT
+AS
+BEGIN
+    SET NOCOUNT ON;
+
+    BEGIN TRANSACTION
+
+    UPDATE [functions].[Leases]
+    SET [Metadata] = @Metadata
+    WHERE [LeaseName] = @LeaseName AND [RequestorName] = @RequestorName AND [HasLease] = 1 AND DATEDIFF(SECOND, [LastRenewal], CURRENT_TIMESTAMP) <= [LeaseExpirationTimeSpan]
+
+    -- COMMIT TRANSACTION will reset @@ROWCOUNT to 0, so we need to use it within the transaction
+    IF @@ROWCOUNT = 1
+        SET @Successful = 1
+    ELSE
+        SET @Successful = 0
+
+    COMMIT TRANSACTION
+END
+GO
+
+IF OBJECT_ID('[functions].[leases_getMetadata]') IS NULL
+BEGIN
+    EXEC('CREATE PROCEDURE [functions].[leases_getMetadata] AS SET NOCOUNT ON');
+END
+GO
+
+ALTER PROCEDURE [functions].[leases_getMetadata]
+@LeaseName NVARCHAR (127), @RequestorName NVARCHAR (127), @Metadata NVARCHAR(MAX) OUTPUT, @HasLease BIT OUTPUT
+AS
+BEGIN
+    SET NOCOUNT ON;
+    
+    SELECT @HasLease = [HasLease] FROM [functions].[Leases] WHERE [LeaseName] = @LeaseName AND [RequestorName] = @RequestorName AND DATEDIFF(SECOND, [LastRenewal], CURRENT_TIMESTAMP) <= [LeaseExpirationTimeSpan]
+
+	-- If no row is selected, HasLease won't have any value assigned. Set it to 0.
+	IF @HasLease <> 1
+		SET @HasLease = 0
+	
+	-- Don't care whether the lease is active or expired
+    SELECT @Metadata = [Metadata] FROM [functions].[Leases] 
+	WHERE [LeaseName] = @LeaseName AND [RequestorName] = @RequestorName
+END
+GO


### PR DESCRIPTION
- This commit contains SQL based lease implementation
- Ideally, we don't want the webjobs SDK to take a dependency on SQL. This is a short term solution. Going forward, this would need to change.

- Also, setup.sql needs some work to make it idempotent.